### PR TITLE
Add FalAPIFluxProV11UltraNode for Flux 1.1 pro Ultra

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from .modules.fal_api_flux_dev_with_lora_and_controlnet_image_to_image_node impo
 from .modules.fal_api_flux_dev_with_lora_and_controlnet_inpaint_node import FalAPIFluxDevWithLoraAndControlNetInpaintNode
 from .modules.fal_api_flux_pro_node import FalAPIFluxProNode
 from .modules.fal_api_flux_pro_v11_node import FalAPIFluxProV11Node
+from .modules.fal_api_flux_pro_v11_ultra_node import FalAPIFluxProV11UltraNode
 from .modules.fal_api_flux_lora_config_node import FalAPIFluxLoraConfigNode
 from .modules.fal_api_flux_controlnet_config_node import FalAPIFluxControlNetConfigNode
 from .modules.fal_api_flux_controlnet_union_config_node import FalAPIFluxControlNetUnionConfigNode
@@ -28,6 +29,7 @@ NODE_CLASS_MAPPINGS = {
     "FalAPIFluxDevWithLoraAndControlNetInpaintNode": FalAPIFluxDevWithLoraAndControlNetInpaintNode,
     "FalAPIFluxProNode": FalAPIFluxProNode,
     "FalAPIFluxProV11Node": FalAPIFluxProV11Node,
+    "FalAPIFluxProV11UltraNode": FalAPIFluxProV11UltraNode,
     "FalAPIFluxLoraConfigNode": FalAPIFluxLoraConfigNode,
     "FalAPIFluxControlNetConfigNode": FalAPIFluxControlNetConfigNode,
     "FalAPIFluxControlNetUnionConfigNode": FalAPIFluxControlNetUnionConfigNode,
@@ -49,6 +51,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "FalAPIFluxDevWithLoraAndControlNetInpaintNode": "Fal API Flux with LoRA and ControlNet Inpaint",
     "FalAPIFluxProNode": "Fal API Flux Pro",
     "FalAPIFluxProV11Node": "Fal API Flux Pro V1.1",
+    "FalAPIFluxProV11UltraNode": "Fal API Flux Pro v1.1 Ultra",
     "FalAPIFluxLoraConfigNode": "Fal API Flux LoRA Config",
     "FalAPIFluxControlNetConfigNode": "Fal API Flux ControlNet Config",
     "FalAPIFluxControlNetUnionConfigNode": "Fal API Flux ControlNet Union Config",
@@ -61,16 +64,17 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 }
 
 __all__ = [
-    'FalAPIFluxDevNode', 
-    'FalAPIFluxDevImageToImageNode', 
-    'FalAPIFluxNodeWithControlNet', 
-    'FalAPIFluxDevWithLoraImageToImageNode', 
-    'FalAPIFluxDevWithLoraInpaintNode', 
-    'FalAPIFluxDevWithLoraAndControlNetNode', 
-    'FalAPIFluxDevWithLoraAndControlNetImageToImageNode', 
+    'FalAPIFluxDevNode',
+    'FalAPIFluxDevImageToImageNode',
+    'FalAPIFluxNodeWithControlNet',
+    'FalAPIFluxDevWithLoraImageToImageNode',
+    'FalAPIFluxDevWithLoraInpaintNode',
+    'FalAPIFluxDevWithLoraAndControlNetNode',
+    'FalAPIFluxDevWithLoraAndControlNetImageToImageNode',
     'FalAPIFluxDevWithLoraAndControlNetInpaintNode',
-    'FalAPIFluxProNode', 
-    'FalAPIFluxProV11Node', 
+    'FalAPIFluxProNode',
+    'FalAPIFluxProV11Node',
+    "FalAPIFluxProV11UltraNode",
     'FalAPIFluxLoraConfigNode', 
     'FalAPIFluxControlNetConfigNode', 
     'FalAPIFluxControlNetUnionConfigNode',

--- a/modules/fal_api_flux_pro_v11_ultra_node.py
+++ b/modules/fal_api_flux_pro_v11_ultra_node.py
@@ -1,0 +1,62 @@
+import logging
+
+from .base_fal_api_flux_node import BaseFalAPIFluxNode
+from .fal_api_flux_pro_v11_node import FalAPIFluxProV11Node
+
+logger = logging.getLogger(__name__)
+
+
+class FalAPIFluxProV11UltraNode(FalAPIFluxProV11Node):
+    """
+    See https://fal.ai/models/fal-ai/flux-pro/v1.1-ultra/api
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.set_api_endpoint("fal-ai/flux-pro/v1.1-ultra")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        # get input types from Flux Pro 1.1
+        input_types = super().INPUT_TYPES()
+
+        # remove `width` and `height` from inputs
+        # the 1.1 ultra API replaces these with `aspect_ratio`
+        del (input_types["required"]["width"])
+        del (input_types["required"]["height"])
+
+        # remove `num_inference_steps` and `guidance_scale`
+        del (input_types["required"]["num_inference_steps"])
+        del (input_types["required"]["guidance_scale"])
+
+        # add `aspect_ratio`
+        input_types["required"]["aspect_ratio"] = (["16:9", "4:3", "21:9", "1:1", "3:4", "9:16", "9:21"],)
+
+        # add `raw`
+        input_types["required"]["raw"] = ("BOOLEAN", {"default": True})
+
+        return input_types
+
+    def prepare_arguments(self, prompt, aspect_ratio, num_images, safety_tolerance,
+                          enable_safety_checker, raw, seed=None, **kwargs):
+        # override from base since we don't have width and height
+        if not self.api_key:
+            raise ValueError("API key is not set. Please check your config.ini file.")
+
+        arguments = {"prompt": prompt, "raw": raw, "num_images": num_images,
+                     "enable_safety_checker": enable_safety_checker,
+                     "safety_tolerance": safety_tolerance, "aspect_ratio": aspect_ratio}
+
+        if seed is not None and seed != 0:
+            arguments["seed"] = seed
+
+        return arguments
+
+
+NODE_CLASS_MAPPINGS = {
+    "FalAPIFluxProV11UltraNode": FalAPIFluxProV11Node
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "FalAPIFluxProV11UltraNode": "Fal API Flux Pro v1.1 Ultra"
+}

--- a/modules/fal_api_flux_pro_v11_ultra_node.py
+++ b/modules/fal_api_flux_pro_v11_ultra_node.py
@@ -35,17 +35,20 @@ class FalAPIFluxProV11UltraNode(FalAPIFluxProV11Node):
         # add `raw`
         input_types["required"]["raw"] = ("BOOLEAN", {"default": True})
 
+        # add `output_format`
+        input_types["required"]["output_format"] = (["jpeg", "png"],)
+
         return input_types
 
     def prepare_arguments(self, prompt, aspect_ratio, num_images, safety_tolerance,
-                          enable_safety_checker, raw, seed=None, **kwargs):
+                          enable_safety_checker, output_format, raw, seed=None, **kwargs):
         # override from base since we don't have width and height
         if not self.api_key:
             raise ValueError("API key is not set. Please check your config.ini file.")
 
         arguments = {"prompt": prompt, "raw": raw, "num_images": num_images,
                      "enable_safety_checker": enable_safety_checker,
-                     "safety_tolerance": safety_tolerance, "aspect_ratio": aspect_ratio}
+                     "safety_tolerance": safety_tolerance, "aspect_ratio": aspect_ratio, "output_format": output_format}
 
         if seed is not None and seed != 0:
             arguments["seed"] = seed


### PR DESCRIPTION
Hi, thanks for creating this custom node! 


Added node for [Fal API Flux Pro 1.1 Ultra](https://fal.ai/models/fal-ai/flux-pro/v1.1-ultra/api#schema-input)

Seems they changed the input schema quite a bit compared to the earlier flux-pro versions, this isn't the cleanest add with deleting some input arguments and overriding a method...

Here's running an example:
![image](https://github.com/user-attachments/assets/6e6dda94-fac5-428b-9538-d377b5a7efc5)
